### PR TITLE
refactor: Update FAQ dropdown to include schema.org markup

### DIFF
--- a/resources/views/components/about/faq/dropdown.blade.php
+++ b/resources/views/components/about/faq/dropdown.blade.php
@@ -1,14 +1,19 @@
-<div class="py-5">
+<div class="py-5" itemscope itemtype="https://schema.org/QAPage">
     <details class="group">
-        <summary class="flex justify-between items-center font-medium cursor-pointer list-none">
-            <span class="text-orange-400">{{$question}}</span>
+        <summary class="flex justify-between items-center font-medium cursor-pointer list-none" itemprop="mainEntity"
+                 itemscope itemtype="https://schema.org/Question">
+            <span class="text-orange-400" itemprop="name">{{$question}}</span>
             <span class="transition text-orange-400 group-open:rotate-180">
-                <svg fill="none" height="24" shape-rendering="geometricPrecision" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" viewBox="0 0 24 24" width="24"><path d="M6 9l6 6 6-6"></path>
+                <svg fill="none" height="24" shape-rendering="geometricPrecision" stroke="currentColor"
+                     stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" viewBox="0 0 24 24" width="24"><path
+                        d="M6 9l6 6 6-6"></path>
                 </svg>
               </span>
         </summary>
-        <p class="text-gray-100 mt-3">
-            {!! $answer !!}
-        </p>
+        <div itemprop="acceptedAnswer" itemscope itemtype="https://schema.org/Answer">
+            <p class="text-gray-100 mt-3" itemprop="text">
+                {!! $answer !!}
+            </p>
+        </div>
     </details>
 </div>


### PR DESCRIPTION
- Added `itemscope` and `itemtype` attributes to the main container div for QAPage schema
- Added `itemprop`, `itemscope`, and `itemtype` attributes to the summary element for Question schema
- Added `itemprop` attribute to the question text span
- Added `itemprop`, `itemscope`, and `itemtype` attributes to the svg element for Answer schema
- Wrapped the answer text in a div with itemprop, itemscope, and itemtype attributes for Answer schema